### PR TITLE
Add compound matcher functionality

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -7,3 +7,6 @@ line_length: 150
 identifier_name:
   min_length:
     warning: 1
+
+type_body_length:
+  - 500

--- a/Moocher.xcodeproj/project.pbxproj
+++ b/Moocher.xcodeproj/project.pbxproj
@@ -52,6 +52,7 @@
 		94F1DECD29253F8100411CCB /* ConformToSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94F1DECC29253F8100411CCB /* ConformToSpec.swift */; };
 		94F1DECF2925403500411CCB /* EqualSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94F1DECE2925403500411CCB /* EqualSpec.swift */; };
 		94F1DED1292540CB00411CCB /* ThrowErrorSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94F1DED0292540CB00411CCB /* ThrowErrorSpec.swift */; };
+		94F91F6F292A7C23005B0D76 /* CompoundEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94F91F6E292A7C23005B0D76 /* CompoundEngine.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -113,6 +114,7 @@
 		94F1DECC29253F8100411CCB /* ConformToSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConformToSpec.swift; sourceTree = "<group>"; };
 		94F1DECE2925403500411CCB /* EqualSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EqualSpec.swift; sourceTree = "<group>"; };
 		94F1DED0292540CB00411CCB /* ThrowErrorSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThrowErrorSpec.swift; sourceTree = "<group>"; };
+		94F91F6E292A7C23005B0D76 /* CompoundEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompoundEngine.swift; sourceTree = "<group>"; };
 		AFEC73E480E3477D37857E7B /* libPods-Moocher.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Moocher.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -189,10 +191,10 @@
 				9499BD7A2922FCF1004C2244 /* BeTruthy.swift */,
 				9499BD762922F3A4004C2244 /* ConformTo.swift */,
 				94CFFAC62926C7BC00D0C0FF /* Contain.swift */,
+				9491131D2928502600B60941 /* EndWith.swift */,
 				9499BD782922F4DF004C2244 /* Equal.swift */,
 				9491131829284C5900B60941 /* StartWith.swift */,
 				94F1DEAE29234AF600411CCB /* ThrowError.swift */,
-				9491131D2928502600B60941 /* EndWith.swift */,
 			);
 			path = Matchers;
 			sourceTree = "<group>";
@@ -228,6 +230,7 @@
 				94F1DEA6291E09CA00411CCB /* MatcherEngine.swift */,
 				94F1DEB4292405A300411CCB /* OptionalActualValue.swift */,
 				94F1DEB22924056000411CCB /* OptionalMatcherEngine.swift */,
+				94F91F6E292A7C23005B0D76 /* CompoundEngine.swift */,
 			);
 			path = Moocher;
 			sourceTree = "<group>";
@@ -446,6 +449,7 @@
 				9499BD7B2922FCF1004C2244 /* BeTruthy.swift in Sources */,
 				9499BD7F2922FECC004C2244 /* BeLessThan.swift in Sources */,
 				94F1DEA1291E091100411CCB /* Expect.swift in Sources */,
+				94F91F6F292A7C23005B0D76 /* CompoundEngine.swift in Sources */,
 				9499BD772922F3A4004C2244 /* ConformTo.swift in Sources */,
 				94F1DEA7291E09CA00411CCB /* MatcherEngine.swift in Sources */,
 				9499BD732922F1A6004C2244 /* BeInstanceOf.swift in Sources */,

--- a/Moocher.xcodeproj/project.pbxproj
+++ b/Moocher.xcodeproj/project.pbxproj
@@ -53,6 +53,8 @@
 		94F1DECF2925403500411CCB /* EqualSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94F1DECE2925403500411CCB /* EqualSpec.swift */; };
 		94F1DED1292540CB00411CCB /* ThrowErrorSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94F1DED0292540CB00411CCB /* ThrowErrorSpec.swift */; };
 		94F91F6F292A7C23005B0D76 /* CompoundEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94F91F6E292A7C23005B0D76 /* CompoundEngine.swift */; };
+		94F91F71292A9E52005B0D76 /* HaveSizeOf.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94F91F70292A9E52005B0D76 /* HaveSizeOf.swift */; };
+		94F91F74292A9FE4005B0D76 /* HaveSizeOfSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94F91F72292A9FBC005B0D76 /* HaveSizeOfSpec.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -115,6 +117,8 @@
 		94F1DECE2925403500411CCB /* EqualSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EqualSpec.swift; sourceTree = "<group>"; };
 		94F1DED0292540CB00411CCB /* ThrowErrorSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThrowErrorSpec.swift; sourceTree = "<group>"; };
 		94F91F6E292A7C23005B0D76 /* CompoundEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompoundEngine.swift; sourceTree = "<group>"; };
+		94F91F70292A9E52005B0D76 /* HaveSizeOf.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HaveSizeOf.swift; sourceTree = "<group>"; };
+		94F91F72292A9FBC005B0D76 /* HaveSizeOfSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HaveSizeOfSpec.swift; sourceTree = "<group>"; };
 		AFEC73E480E3477D37857E7B /* libPods-Moocher.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Moocher.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -193,6 +197,7 @@
 				94CFFAC62926C7BC00D0C0FF /* Contain.swift */,
 				9491131D2928502600B60941 /* EndWith.swift */,
 				9499BD782922F4DF004C2244 /* Equal.swift */,
+				94F91F70292A9E52005B0D76 /* HaveSizeOf.swift */,
 				9491131829284C5900B60941 /* StartWith.swift */,
 				94F1DEAE29234AF600411CCB /* ThrowError.swift */,
 			);
@@ -277,6 +282,7 @@
 				94CFFAC8292744BF00D0C0FF /* ContainSpec.swift */,
 				9491131F2929287A00B60941 /* EndWithSpec.swift */,
 				94F1DECE2925403500411CCB /* EqualSpec.swift */,
+				94F91F72292A9FBC005B0D76 /* HaveSizeOfSpec.swift */,
 				9491131A29284E6600B60941 /* StartWithSpec.swift */,
 				94F1DED0292540CB00411CCB /* ThrowErrorSpec.swift */,
 			);
@@ -444,6 +450,7 @@
 				9491131E2928502600B60941 /* EndWith.swift in Sources */,
 				9499BD832923009B004C2244 /* BeGreaterThan.swift in Sources */,
 				9499BD812922FFC8004C2244 /* BeLessThanOrEqualTo.swift in Sources */,
+				94F91F71292A9E52005B0D76 /* HaveSizeOf.swift in Sources */,
 				9499BD852923440B004C2244 /* BeGreaterThanOrEqualTo.swift in Sources */,
 				9499BD752922F1E9004C2244 /* BeKindOf.swift in Sources */,
 				9499BD7B2922FCF1004C2244 /* BeTruthy.swift in Sources */,
@@ -477,6 +484,7 @@
 				94F1DEC62924976F00411CCB /* BeLessThanSpec.swift in Sources */,
 				9499BD6A291ECD42004C2244 /* GrizzlyBear.swift in Sources */,
 				9499BD6C291F1E9E004C2244 /* BJJBelt.swift in Sources */,
+				94F91F74292A9FE4005B0D76 /* HaveSizeOfSpec.swift in Sources */,
 				94F1DEC42924964300411CCB /* BeKindOfSpec.swift in Sources */,
 				949113212929287E00B60941 /* EndWithSpec.swift in Sources */,
 				94F1DEC829253E0200411CCB /* BeLessThanOrEqualToSpec.swift in Sources */,

--- a/Sources/Moocher/CompoundEngine.swift
+++ b/Sources/Moocher/CompoundEngine.swift
@@ -1,0 +1,32 @@
+//MIT License
+//
+//Copyright (c) 2022 Ryan Baumbach <github@ryan.codes>
+//
+//Permission is hereby granted, free of charge, to any person obtaining a copy
+//of this software and associated documentation files (the "Software"), to deal
+//in the Software without restriction, including without limitation the rights
+//to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//copies of the Software, and to permit persons to whom the Software is
+//furnished to do so, subject to the following conditions:
+//
+//The above copyright notice and this permission notice shall be included in all
+//copies or substantial portions of the Software.
+//
+//THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//SOFTWARE.
+
+import Foundation
+
+public struct CompoundEngine<T> {
+    let previousMatcherEngine: MatcherEngine<T>
+    
+    public var and: MatcherEngine<T> {
+        return MatcherEngine(actualValue: previousMatcherEngine.actualValue,
+                             to: previousMatcherEngine.to)
+    }
+}

--- a/Sources/Moocher/MatcherEngine.swift
+++ b/Sources/Moocher/MatcherEngine.swift
@@ -276,23 +276,29 @@ public struct MatcherEngine<T> {
     
     // MARK: - Sequence matchers
     
+    @discardableResult
     public func contain<U>(_ item: U,
                            file: StaticString = #filePath,
-                           line: UInt = #line) where T: Sequence, T.Element: Equatable, T.Element == U {
+                           line: UInt = #line) -> CompoundEngine<T> where T: Sequence, T.Element: Equatable, T.Element == U {
         Contain().contain(actualValue.value,
                           item,
                           to: to,
                           file: file,
                           line: line)
+        
+        return CompoundEngine(previousMatcherEngine: self)
     }
     
+    @discardableResult
     public func contain(_ item: T,
                         file: StaticString = #filePath,
-                        line: UInt = #line) where T == String {
+                        line: UInt = #line) -> CompoundEngine<T> where T == String {
         Contain().contain(actualValue.value,
                           item,
                           to: to,
                           file: file,
                           line: line)
+        
+        return CompoundEngine(previousMatcherEngine: self)
     }
 }

--- a/Sources/Moocher/MatcherEngine.swift
+++ b/Sources/Moocher/MatcherEngine.swift
@@ -248,24 +248,30 @@ public struct MatcherEngine<T> {
                           line: line)
     }
     
+    @discardableResult
     public func startWith<U>(_ item: U,
                              file: StaticString = #filePath,
-                             line: UInt = #line) where T: Collection, T.Element: Equatable, T.Element == U {
+                             line: UInt = #line) -> CompoundEngine<T> where T: Collection, T.Element: Equatable, T.Element == U {
         StartWith().startWith(actualValue.value,
                               item,
                               to: to,
                               file: file,
                               line: line)
+        
+        return CompoundEngine(previousMatcherEngine: self)
     }
     
+    @discardableResult
     public func endWith<U>(_ item: U,
                            file: StaticString = #filePath,
-                           line: UInt = #line) where T: Collection, T.Element: Equatable, T.Element == U {
+                           line: UInt = #line) -> CompoundEngine<T> where T: Collection, T.Element: Equatable, T.Element == U {
         EndWith().endWith(actualValue.value,
                           item,
                           to: to,
                           file: file,
                           line: line)
+        
+        return CompoundEngine(previousMatcherEngine: self)
     }
     
     // MARK: - Sequence matchers

--- a/Sources/Moocher/MatcherEngine.swift
+++ b/Sources/Moocher/MatcherEngine.swift
@@ -274,6 +274,19 @@ public struct MatcherEngine<T> {
         return CompoundEngine(previousMatcherEngine: self)
     }
     
+    @discardableResult
+    public func haveSizeOf(_ size: Int,
+                           file: StaticString = #filePath,
+                           line: UInt = #line) -> CompoundEngine<T> where T: Collection {
+        HaveSizeOf().haveSizeOf(actualValue.value,
+                                size,
+                                to: to,
+                                file: file,
+                                line: line)
+        
+        return CompoundEngine(previousMatcherEngine: self)
+    }
+    
     // MARK: - Sequence matchers
     
     @discardableResult

--- a/Sources/Moocher/Matchers/HaveSizeOf.swift
+++ b/Sources/Moocher/Matchers/HaveSizeOf.swift
@@ -1,0 +1,43 @@
+//MIT License
+//
+//Copyright (c) 2022 Ryan Baumbach <github@ryan.codes>
+//
+//Permission is hereby granted, free of charge, to any person obtaining a copy
+//of this software and associated documentation files (the "Software"), to deal
+//in the Software without restriction, including without limitation the rights
+//to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//copies of the Software, and to permit persons to whom the Software is
+//furnished to do so, subject to the following conditions:
+//
+//The above copyright notice and this permission notice shall be included in all
+//copies or substantial portions of the Software.
+//
+//THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//SOFTWARE.
+
+import XCTest
+
+struct HaveSizeOf {
+    func haveSizeOf<T>(_ value: T,
+                       _ size: Int,
+                       to: Bool,
+                       file: StaticString = #filePath,
+                       line: UInt = #line) where T: Collection {
+        if to {
+            XCTAssertEqual(value.count,
+                           size,
+                           file: file,
+                           line: line)
+        } else {
+            XCTAssertNotEqual(value.count,
+                              size,
+                              file: file,
+                              line: line)
+        }
+    }
+}

--- a/Tests/Specs/Matchers/ContainSpec.swift
+++ b/Tests/Specs/Matchers/ContainSpec.swift
@@ -5,8 +5,12 @@ final class ContainSpec: XCTestCase {
     func testToContainWithSequence() {
         expect([1, 2, 3]).to.contain(1)
         
+        // Note: The '_ =' is only used to silence a warning from XCTExpectFailure
+        // throughout the specs
+        // This is not required for usage
+        
         XCTExpectFailure("array should not contain 99") {
-            expect([1, 2, 3]).to.contain(99)
+            _ = expect([1, 2, 3]).to.contain(99)
         }
     }
     
@@ -16,7 +20,7 @@ final class ContainSpec: XCTestCase {
         XCTExpectFailure("the set should contain 8") {
             let bag: Set<Int> = [2, 4, 8, 16]
             
-            expect(bag).toNot.contain(8)
+            _ = expect(bag).toNot.contain(8)
         }
     }
     
@@ -24,7 +28,7 @@ final class ContainSpec: XCTestCase {
         expect("Bill and Ted").to.contain("d")
         
         XCTExpectFailure("Excellent should not contain !") {
-            expect("Excellent").to.contain("!")
+            _ = expect("Excellent").to.contain("!")
         }
     }
     
@@ -32,7 +36,31 @@ final class ContainSpec: XCTestCase {
         expect("Wyld Stallyns").toNot.contain("i")
         
         XCTExpectFailure("Bogus should contain B") {
-            expect("Bogus").toNot.contain("B")
+            _ = expect("Bogus").toNot.contain("B")
+        }
+    }
+    
+    func testToContainWithCompoundMatcher() {
+        expect([1, 2, 3]).to.contain(1).and.startWith(1)
+        
+        XCTExpectFailure("array should not contain four") {
+            _ = expect(["one", "two", "three"]).to.contain("four").and.startWith("one")
+        }
+        
+        XCTExpectFailure("array should not start with four") {
+            _ = expect(["one", "two", "three"]).to.contain("one").and.startWith("four")
+        }
+    }
+    
+    func testToNotContainWithCompoundMatcher() {
+        expect([1, 2, 3]).toNot.contain(99).and.startWith(2)
+        
+        XCTExpectFailure("array should not contain one") {
+            _ = expect(["one", "two", "three"]).toNot.contain("one").and.startWith("two")
+        }
+        
+        XCTExpectFailure("array should not start with four") {
+            _ = expect(["one", "two", "three"]).toNot.contain("se7en").and.startWith("one")
         }
     }
     
@@ -40,7 +68,7 @@ final class ContainSpec: XCTestCase {
         expect("Bob and Doug").to.contain("Doug")
 
         XCTExpectFailure("McKenzie should not contain Hoser") {
-            expect("McKenzie").to.contain("Hoser")
+            _ = expect("McKenzie").to.contain("Hoser")
         }
     }
 
@@ -48,7 +76,31 @@ final class ContainSpec: XCTestCase {
         expect("Canada").toNot.contain("Maple Leaf")
 
         XCTExpectFailure("The Great White North should contain North") {
-            expect("The Great White North").toNot.contain("North")
+            _ = expect("The Great White North").toNot.contain("North")
+        }
+    }
+    
+    func testToContainStringUsingSubstringWithCompoundMatcher() {
+        expect("Bob and Doug").to.contain("Doug").and.startWith("B")
+        
+        XCTExpectFailure("string should not contain Hoser") {
+            _ = expect("McKenzie").to.contain("Hoser").and.startWith("M")
+        }
+        
+        XCTExpectFailure("string should not start with D") {
+            _ = expect("McKenzie").to.contain("Hoser").and.startWith("D")
+        }
+    }
+    
+    func testToNotContainStringUsingSubstringWithCompoundMatcher() {
+        expect("Canada").toNot.contain("Maple Leaf").and.startWith("D")
+        
+        XCTExpectFailure("string should contain North") {
+            _ = expect("The Great White North").toNot.contain("North").and.startWith("G")
+        }
+        
+        XCTExpectFailure("string should not start with T") {
+            _ = expect("The Great White North").toNot.contain("Hosehead").and.startWith("T")
         }
     }
 }

--- a/Tests/Specs/Matchers/EndWithSpec.swift
+++ b/Tests/Specs/Matchers/EndWithSpec.swift
@@ -5,8 +5,12 @@ final class EndWithSpec: XCTestCase {
     func testToEndWith() {
         expect([1, 2, 3]).to.endWith(3)
         
+        // Note: The '_ =' is only used to silence a warning from XCTExpectFailure
+        // throughout the specs
+        // This is not required for usage
+        
         XCTExpectFailure("array should not end with four") {
-            expect(["one", "two", "three"]).to.endWith("four")
+            _ = expect(["one", "two", "three"]).to.endWith("four")
         }
     }
     
@@ -14,7 +18,31 @@ final class EndWithSpec: XCTestCase {
         expect([4, 5, 6]).toNot.endWith(1)
         
         XCTExpectFailure("array should end with c") {
-            expect(["a", "b", "c"]).toNot.endWith("c")
+            _ = expect(["a", "b", "c"]).toNot.endWith("c")
+        }
+    }
+    
+    func testToEndWithCompoundMatcher() {
+        expect([1, 2, 3]).to.endWith(3).and.startWith(1)
+        
+        XCTExpectFailure("array should not end with four") {
+            _ = expect(["one", "two", "three"]).to.endWith("four").and.startWith("one")
+        }
+        
+        XCTExpectFailure("array should not start with four") {
+            _ = expect(["one", "two", "three"]).to.endWith("three").and.startWith("four")
+        }
+    }
+    
+    func testToNotEndWithCompoundMatcher() {
+        expect([1, 2, 3]).toNot.endWith(7).and.startWith(4)
+        
+        XCTExpectFailure("array should not end with three") {
+            _ = expect(["one", "two", "three"]).toNot.endWith("three").and.startWith("one")
+        }
+        
+        XCTExpectFailure("array should not start with one") {
+            _ = expect(["one", "two", "three"]).toNot.endWith("se7en").and.startWith("one")
         }
     }
 }

--- a/Tests/Specs/Matchers/HaveSizeOfSpec.swift
+++ b/Tests/Specs/Matchers/HaveSizeOfSpec.swift
@@ -1,0 +1,48 @@
+import XCTest
+@testable import Moocher
+
+final class HaveSizeOfSpec: XCTestCase {
+    func testToHaveSizeOf() {
+        expect([1, 2, 3]).to.haveSizeOf(3)
+        
+        // Note: The '_ =' is only used to silence a warning from XCTExpectFailure
+        // throughout the specs
+        // This is not required for usage
+        
+        XCTExpectFailure("array should not have a size of 4") {
+            _ = expect(["one", "two", "three"]).to.haveSizeOf(4)
+        }
+    }
+    
+    func testToNotHaveSizeOf() {
+        expect([1, 2, 3]).toNot.haveSizeOf(99)
+        
+        XCTExpectFailure("array should have a size of 3") {
+            _ = expect(["one", "two", "three"]).toNot.haveSizeOf(3)
+        }
+    }
+    
+    func testToHaveSizeOfWithCompoundMatcher() {
+        expect([1, 2, 3]).to.haveSizeOf(3).and.startWith(1)
+        
+        XCTExpectFailure("array should have a size of 3") {
+            _ = expect([1, 2, 3]).to.haveSizeOf(4).and.startWith(1)
+        }
+        
+        XCTExpectFailure("array should not start with 2") {
+            _ = expect([1, 2, 3]).to.haveSizeOf(3).and.startWith(2)
+        }
+    }
+    
+    func testToNotHaveSizeOfWithCompoundMatcher() {
+        expect([1, 2, 3]).toNot.haveSizeOf(1).and.startWith(2)
+        
+        XCTExpectFailure("array should have a size of 3") {
+            _ = expect([1, 2, 3]).toNot.haveSizeOf(3).and.startWith(2)
+        }
+        
+        XCTExpectFailure("array should not start with 1") {
+            _ = expect([1, 2, 3]).toNot.haveSizeOf(99).and.startWith(1)
+        }
+    }
+}

--- a/Tests/Specs/Matchers/StartWithSpec.swift
+++ b/Tests/Specs/Matchers/StartWithSpec.swift
@@ -5,8 +5,12 @@ final class StartWithSpec: XCTestCase {
     func testToStartWith() {
         expect([1, 2, 3]).to.startWith(1)
         
+        // Note: The '_ =' is only used to silence a warning from XCTExpectFailure
+        // throughout the specs
+        // This is not required for usage
+        
         XCTExpectFailure("array should not start with four") {
-            expect(["one", "two", "three"]).to.startWith("four")
+            _ = expect(["one", "two", "three"]).to.startWith("four")
         }
     }
     
@@ -14,7 +18,31 @@ final class StartWithSpec: XCTestCase {
         expect([4, 5, 6]).toNot.startWith(1)
         
         XCTExpectFailure("array should start with four") {
-            expect(["four", "five", "six"]).toNot.startWith("four")
+            _ = expect(["four", "five", "six"]).toNot.startWith("four")
+        }
+    }
+    
+    func testToStartWithCompoundMatcher() {
+        expect([1, 2, 3]).to.startWith(1).and.endWith(3)
+        
+        XCTExpectFailure("array should not start with four") {
+            _ = expect(["one", "two", "three"]).to.startWith("four").and.endWith("three")
+        }
+        
+        XCTExpectFailure("array should not end with four") {
+            _ = expect(["one", "two", "three"]).to.startWith("one").and.endWith("four")
+        }
+    }
+    
+    func testToNotStartWithCompoundMatcher() {
+        expect([1, 2, 3]).toNot.startWith(7).and.endWith(4)
+        
+        XCTExpectFailure("array should not start with one") {
+            _ = expect(["one", "two", "three"]).toNot.startWith("one").and.endWith("four")
+        }
+        
+        XCTExpectFailure("array should not end with three") {
+            _ = expect(["one", "two", "three"]).toNot.startWith("se7en").and.endWith("three")
         }
     }
 }

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -20,6 +20,11 @@ platform :ios do
 
   desc "Runs the specs"
   lane :specs do
+    swiftlint(strict: true,
+              quiet: true,
+              config_file: ".swiftlint.yml",
+              executable: "Pods/SwiftLint/swiftlint")
+
     scan(scheme: "Moocher",
          output_style: "rspec")
   end


### PR DESCRIPTION
This PR adds the ability to have compound matchers with some of the matchers:

ex:

```swift
expect([1, 2, 3]).to.contain(3).and.startWith(1)
```

It also adds `haveSizeOf` matcher for `Collection` types.