### PR TITLE
Create expectFailure that wraps XCTExpectFailure

### DIFF
--- a/Sources/Moocher/Expect.swift
+++ b/Sources/Moocher/Expect.swift
@@ -20,7 +20,7 @@
 //OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 //SOFTWARE.
 
-import Foundation
+import XCTest
 
 public func expect<T>(_ value: T) -> ActualValue<T> {
     return ActualValue(value: value)
@@ -28,4 +28,11 @@ public func expect<T>(_ value: T) -> ActualValue<T> {
 
 public func expect<T>(_ value: T?) -> OptionalActualValue<T> {
     return OptionalActualValue(value: value)
+}
+
+public func expectFailure(_ failureReason: String,
+                          failingBlock: () throws -> Void) {
+    XCTExpectFailure(failureReason) {
+        try? failingBlock()
+    }
 }

--- a/Tests/Specs/Matchers/BeEmptySpec.swift
+++ b/Tests/Specs/Matchers/BeEmptySpec.swift
@@ -15,7 +15,7 @@ final class BeEmptySpec: XCTestCase {
     func testToBeEmptyWithCollection() {
         expect(emptyArray).to.beEmpty()
         
-        XCTExpectFailure("non empty array should not be empty") {
+        expectFailure("non empty array should not be empty") {
             expect([1, 2, 3]).to.beEmpty()
         }
     }
@@ -23,7 +23,7 @@ final class BeEmptySpec: XCTestCase {
     func testToNotBeEmptyWithCollection() {
         expect([1, 2, 3]).toNot.beEmpty()
         
-        XCTExpectFailure("emptyArray should not be empty") {
+        expectFailure("emptyArray should not be empty") {
             expect(emptyArray).toNot.beEmpty()
         }
     }
@@ -31,7 +31,7 @@ final class BeEmptySpec: XCTestCase {
     func testToBeEmptyWithString() {
         expect(emptyString).to.beEmpty()
         
-        XCTExpectFailure("non empty string should not be empty") {
+        expectFailure("non empty string should not be empty") {
             expect("DeLorean").to.beEmpty()
         }
     }
@@ -39,7 +39,7 @@ final class BeEmptySpec: XCTestCase {
     func testToNotBeEmptyWithString() {
         expect("flux capacitor").toNot.beEmpty()
         
-        XCTExpectFailure("emptyString should not be empty") {
+        expectFailure("emptyString should not be empty") {
             expect(emptyString).toNot.beEmpty()
         }
     }

--- a/Tests/Specs/Matchers/BeFalsySpec.swift
+++ b/Tests/Specs/Matchers/BeFalsySpec.swift
@@ -5,7 +5,7 @@ final class BeFalsySpec: XCTestCase {
     func testToBeFalsy() {
         expect(false).to.beFalsy()
         
-        XCTExpectFailure("true should not be falsy") {
+        expectFailure("true should not be falsy") {
             expect(true).to.beFalsy()
         }
         
@@ -15,7 +15,7 @@ final class BeFalsySpec: XCTestCase {
     func testToNotBeFalsy() {
         expect(true).toNot.beFalsy()
         
-        XCTExpectFailure("false should not not be falsy") {
+        expectFailure("false should not not be falsy") {
             expect(false).toNot.beFalsy()
         }
         

--- a/Tests/Specs/Matchers/BeGreaterThanOrEqualSpec.swift
+++ b/Tests/Specs/Matchers/BeGreaterThanOrEqualSpec.swift
@@ -7,11 +7,11 @@ final class BeGreaterThanOrEqualSpec: XCTestCase {
         expect(10).to.beGreaterThanOrEqualTo(10)
         expect(BJJBelt.black).to.beGreaterThanOrEqualTo(BJJBelt.black)
         
-        XCTExpectFailure("9 should not be greater than or equal to 10") {
+        expectFailure("9 should not be greater than or equal to 10") {
             expect(9).to.beGreaterThanOrEqualTo(10)
         }
         
-        XCTExpectFailure("white belt should not be greater than or equal to red belt") {
+        expectFailure("white belt should not be greater than or equal to red belt") {
             expect(BJJBelt.white).to.beGreaterThanOrEqualTo(BJJBelt.red)
         }
     }
@@ -20,11 +20,11 @@ final class BeGreaterThanOrEqualSpec: XCTestCase {
         expect(8).toNot.beGreaterThanOrEqualTo(9)
         expect(BJJBelt.blue).toNot.beGreaterThanOrEqualTo(BJJBelt.purple)
         
-        XCTExpectFailure("10 should not not be greater than or equal to 9") {
+        expectFailure("10 should not not be greater than or equal to 9") {
             expect(10).toNot.beGreaterThanOrEqualTo(9)
         }
         
-        XCTExpectFailure("brown belt should not not be greater than or equal to blue belt") {
+        expectFailure("brown belt should not not be greater than or equal to blue belt") {
             expect(BJJBelt.brown).toNot.beGreaterThanOrEqualTo(BJJBelt.blue)
         }
     }

--- a/Tests/Specs/Matchers/BeGreaterThanSpec.swift
+++ b/Tests/Specs/Matchers/BeGreaterThanSpec.swift
@@ -6,11 +6,11 @@ final class BeGreaterThanSpec: XCTestCase {
         expect(10).to.beGreaterThan(9)
         expect(BJJBelt.black).to.beGreaterThan(BJJBelt.purple)
         
-        XCTExpectFailure("9 is not greater than 9") {
+        expectFailure("9 is not greater than 9") {
             expect(9).to.beGreaterThan(9)
         }
         
-        XCTExpectFailure("white belt is not greater than brown belt") {
+        expectFailure("white belt is not greater than brown belt") {
             expect(BJJBelt.white).to.beGreaterThan(BJJBelt.brown)
         }
     }
@@ -21,11 +21,11 @@ final class BeGreaterThanSpec: XCTestCase {
         
         expect(BJJBelt.blue).toNot.beGreaterThan(BJJBelt.purple)
         
-        XCTExpectFailure("10 should not not be greater than 9") {
+        expectFailure("10 should not not be greater than 9") {
             expect(10).toNot.beGreaterThan(9)
         }
         
-        XCTExpectFailure("brown belt is not not greater than blue belt") {
+        expectFailure("brown belt is not not greater than blue belt") {
             expect(BJJBelt.brown).toNot.beGreaterThan(BJJBelt.blue)
         }
     }

--- a/Tests/Specs/Matchers/BeInstanceOfSpec.swift
+++ b/Tests/Specs/Matchers/BeInstanceOfSpec.swift
@@ -17,7 +17,7 @@ final class BeInstanceOfSpec: XCTestCase {
     func testToBeInstanceOf() {
         expect(dog1).to.beInstanceOf(dog2)
         
-        XCTExpectFailure("dog1 should not be instance of dog3") {
+        expectFailure("dog1 should not be instance of dog3") {
             expect(dog1).to.beInstanceOf(dog3)
         }
     }
@@ -25,7 +25,7 @@ final class BeInstanceOfSpec: XCTestCase {
     func testToNotBeInstanceOf() {
         expect(dog1).toNot.beInstanceOf(dog3)
         
-        XCTExpectFailure("dog1 should be instance of dog2") {
+        expectFailure("dog1 should be instance of dog2") {
             expect(dog1).toNot.beInstanceOf(dog2)
         }
     }

--- a/Tests/Specs/Matchers/BeKindOfSpec.swift
+++ b/Tests/Specs/Matchers/BeKindOfSpec.swift
@@ -16,11 +16,11 @@ final class BeKindOfSpec: XCTestCase {
         expect(fish).to.beKindOf(Fish.self)
         expect(dog).to.beKindOf(WildAnimal.self)
         
-        XCTExpectFailure("dog should not be a Fish") {
+        expectFailure("dog should not be a Fish") {
             expect(dog).to.beKindOf(Fish.self)
         }
         
-        XCTExpectFailure("dog should not be a Bear") {
+        expectFailure("dog should not be a Bear") {
             expect(dog).to.beKindOf(Bear.self)
         }
     }
@@ -29,11 +29,11 @@ final class BeKindOfSpec: XCTestCase {
         expect(fish).toNot.beKindOf(WildAnimal.self)
         expect(dog).toNot.beKindOf(Bear.self)
         
-        XCTExpectFailure("dog should be a wolf") {
+        expectFailure("dog should be a wolf") {
             expect(dog).toNot.beKindOf(Wolf.self)
         }
         
-        XCTExpectFailure("dog should be a WildAnimal") {
+        expectFailure("dog should be a WildAnimal") {
             expect(dog).toNot.beKindOf(WildAnimal.self)
         }
     }

--- a/Tests/Specs/Matchers/BeLessThanOrEqualToSpec.swift
+++ b/Tests/Specs/Matchers/BeLessThanOrEqualToSpec.swift
@@ -8,11 +8,11 @@ final class BeLessThanOrEqualToSpec: XCTestCase {
         expect(BJJBelt.white).to.beLessThanOrEqualTo(BJJBelt.white)
         expect(BJJBelt.white).to.beLessThanOrEqualTo(BJJBelt.blue)
         
-        XCTExpectFailure("9 should not be less than or equal to 8") {
+        expectFailure("9 should not be less than or equal to 8") {
             expect(9).to.beLessThanOrEqualTo(8)
         }
         
-        XCTExpectFailure("black belt should not be less than or equal to white belt") {
+        expectFailure("black belt should not be less than or equal to white belt") {
             expect(BJJBelt.black).to.beLessThanOrEqualTo(BJJBelt.white)
         }
     }
@@ -21,11 +21,11 @@ final class BeLessThanOrEqualToSpec: XCTestCase {
         expect(9).toNot.beLessThanOrEqualTo(8)
         expect(BJJBelt.blue).toNot.beLessThanOrEqualTo(BJJBelt.white)
         
-        XCTExpectFailure("9 should be less than or equal to 10") {
+        expectFailure("9 should be less than or equal to 10") {
             expect(9).toNot.beLessThanOrEqualTo(10)
         }
         
-        XCTExpectFailure("white belt should be less than or equal to blue belt") {
+        expectFailure("white belt should be less than or equal to blue belt") {
             expect(BJJBelt.white).toNot.beLessThanOrEqualTo(BJJBelt.blue)
         }
     }

--- a/Tests/Specs/Matchers/BeLessThanSpec.swift
+++ b/Tests/Specs/Matchers/BeLessThanSpec.swift
@@ -6,11 +6,11 @@ final class BeLessThanSpec: XCTestCase {
         expect(9).to.beLessThan(10)
         expect(BJJBelt.white).to.beLessThan(BJJBelt.blue)
         
-        XCTExpectFailure("9 should not be less than 9") {
+        expectFailure("9 should not be less than 9") {
             expect(9).to.beLessThan(9)
         }
         
-        XCTExpectFailure("white belt should not be less than white belt") {
+        expectFailure("white belt should not be less than white belt") {
             expect(BJJBelt.white).to.beLessThan(BJJBelt.white)
         }
     }
@@ -20,11 +20,11 @@ final class BeLessThanSpec: XCTestCase {
         expect(9).toNot.beLessThan(9)
         expect(BJJBelt.blue).toNot.beLessThan(BJJBelt.white)
         
-        XCTExpectFailure("9 should be less than 10") {
+        expectFailure("9 should be less than 10") {
             expect(9).toNot.beLessThan(10)
         }
         
-        XCTExpectFailure("white belt should be less than blue belt") {
+        expectFailure("white belt should be less than blue belt") {
             expect(BJJBelt.white).toNot.beLessThan(BJJBelt.blue)
         }
     }

--- a/Tests/Specs/Matchers/BeNilSpec.swift
+++ b/Tests/Specs/Matchers/BeNilSpec.swift
@@ -14,7 +14,7 @@ final class BeNilSpec: XCTestCase {
     func testToBeNil() {
         expect(somethingNil).to.beNil()
                 
-        XCTExpectFailure("somethingNonNil should not be nil") {
+        expectFailure("somethingNonNil should not be nil") {
             expect(somethingNonNil).to.beNil()
         }
     }
@@ -22,7 +22,7 @@ final class BeNilSpec: XCTestCase {
     func testToNotBeNil() {
         expect(somethingNonNil).toNot.beNil()
         
-        XCTExpectFailure("somethingNil should not be nil") {
+        expectFailure("somethingNil should not be nil") {
             expect(somethingNil).toNot.beNil()
         }
     }

--- a/Tests/Specs/Matchers/BeTruthySpec.swift
+++ b/Tests/Specs/Matchers/BeTruthySpec.swift
@@ -14,7 +14,7 @@ final class BeTruthySpec: XCTestCase {
     func testToBeTruthy() {
         expect(true).to.beTruthy()
         
-        XCTExpectFailure("false should not be truthy") {
+        expectFailure("false should not be truthy") {
             expect(false).to.beTruthy()
         }
     }
@@ -22,7 +22,7 @@ final class BeTruthySpec: XCTestCase {
     func testToNotBeTruthy() {
         expect(false).toNot.beTruthy()
         
-        XCTExpectFailure("true should not not be truthy") {
+        expectFailure("true should not not be truthy") {
             expect(true).toNot.beTruthy()
         }
     }

--- a/Tests/Specs/Matchers/ConformToSpec.swift
+++ b/Tests/Specs/Matchers/ConformToSpec.swift
@@ -16,7 +16,7 @@ final class ConformTo: XCTestCase {
     func testToConformTo() {
         expect(dog).to.conformTo(Wolf.self)
         
-        XCTExpectFailure("true should not not be truthy") {
+        expectFailure("true should not not be truthy") {
             expect(dog).to.conformTo(Bear.self)
         }
     }
@@ -24,7 +24,7 @@ final class ConformTo: XCTestCase {
     func testToNotConformTo() {
         expect(dog).toNot.conformTo(Bear.self)
         
-        XCTExpectFailure("true should not not be truthy") {
+        expectFailure("true should not not be truthy") {
             expect(grizzlyBear).toNot.conformTo(Bear.self)
         }
     }

--- a/Tests/Specs/Matchers/ContainSpec.swift
+++ b/Tests/Specs/Matchers/ContainSpec.swift
@@ -4,103 +4,99 @@ import XCTest
 final class ContainSpec: XCTestCase {
     func testToContainWithSequence() {
         expect([1, 2, 3]).to.contain(1)
-        
-        // Note: The '_ =' is only used to silence a warning from XCTExpectFailure
-        // throughout the specs
-        // This is not required for usage
-        
-        XCTExpectFailure("array should not contain 99") {
-            _ = expect([1, 2, 3]).to.contain(99)
+
+        expectFailure("array should not contain 99") {
+            expect([1, 2, 3]).to.contain(99)
         }
     }
     
     func testToNotContainWithSequence() {
         expect(["tacos", "burritos", "sopes"]).toNot.contain("enchiladas")
         
-        XCTExpectFailure("the set should contain 8") {
+        expectFailure("the set should contain 8") {
             let bag: Set<Int> = [2, 4, 8, 16]
             
-            _ = expect(bag).toNot.contain(8)
+            expect(bag).toNot.contain(8)
         }
     }
     
     func testToContainWithStringUsingCharacter() {
         expect("Bill and Ted").to.contain("d")
         
-        XCTExpectFailure("Excellent should not contain !") {
-            _ = expect("Excellent").to.contain("!")
+        expectFailure("Excellent should not contain !") {
+            expect("Excellent").to.contain("!")
         }
     }
     
     func testToNotContainStringUsingCharacter() {
         expect("Wyld Stallyns").toNot.contain("i")
         
-        XCTExpectFailure("Bogus should contain B") {
-            _ = expect("Bogus").toNot.contain("B")
+        expectFailure("Bogus should contain B") {
+            expect("Bogus").toNot.contain("B")
         }
     }
     
     func testToContainWithCompoundMatcher() {
         expect([1, 2, 3]).to.contain(1).and.startWith(1)
         
-        XCTExpectFailure("array should not contain four") {
-            _ = expect(["one", "two", "three"]).to.contain("four").and.startWith("one")
+        expectFailure("array should not contain four") {
+            expect(["one", "two", "three"]).to.contain("four").and.startWith("one")
         }
         
-        XCTExpectFailure("array should not start with four") {
-            _ = expect(["one", "two", "three"]).to.contain("one").and.startWith("four")
+        expectFailure("array should not start with four") {
+            expect(["one", "two", "three"]).to.contain("one").and.startWith("four")
         }
     }
     
     func testToNotContainWithCompoundMatcher() {
         expect([1, 2, 3]).toNot.contain(99).and.startWith(2)
         
-        XCTExpectFailure("array should not contain one") {
-            _ = expect(["one", "two", "three"]).toNot.contain("one").and.startWith("two")
+        expectFailure("array should not contain one") {
+            expect(["one", "two", "three"]).toNot.contain("one").and.startWith("two")
         }
         
-        XCTExpectFailure("array should not start with four") {
-            _ = expect(["one", "two", "three"]).toNot.contain("se7en").and.startWith("one")
+        expectFailure("array should not start with four") {
+            expect(["one", "two", "three"]).toNot.contain("se7en").and.startWith("one")
         }
     }
     
     func testToContainWithStringUsingSubstring() {
         expect("Bob and Doug").to.contain("Doug")
 
-        XCTExpectFailure("McKenzie should not contain Hoser") {
-            _ = expect("McKenzie").to.contain("Hoser")
+        expectFailure("McKenzie should not contain Hoser") {
+            expect("McKenzie").to.contain("Hoser")
         }
     }
 
     func testToNotContainStringUsingSubstring() {
         expect("Canada").toNot.contain("Maple Leaf")
 
-        XCTExpectFailure("The Great White North should contain North") {
-            _ = expect("The Great White North").toNot.contain("North")
+        expectFailure("The Great White North should contain North") {
+            expect("The Great White North").toNot.contain("North")
         }
     }
     
     func testToContainStringUsingSubstringWithCompoundMatcher() {
         expect("Bob and Doug").to.contain("Doug").and.startWith("B")
         
-        XCTExpectFailure("string should not contain Hoser") {
-            _ = expect("McKenzie").to.contain("Hoser").and.startWith("M")
+        expectFailure("string should not contain Hoser") {
+            expect("McKenzie").to.contain("Hoser").and.startWith("M")
         }
         
-        XCTExpectFailure("string should not start with D") {
-            _ = expect("McKenzie").to.contain("Hoser").and.startWith("D")
+        expectFailure("string should not start with D") {
+            expect("McKenzie").to.contain("Hoser").and.startWith("D")
         }
     }
     
     func testToNotContainStringUsingSubstringWithCompoundMatcher() {
         expect("Canada").toNot.contain("Maple Leaf").and.startWith("D")
         
-        XCTExpectFailure("string should contain North") {
-            _ = expect("The Great White North").toNot.contain("North").and.startWith("G")
+        expectFailure("string should contain North") {
+            expect("The Great White North").toNot.contain("North").and.startWith("G")
         }
         
-        XCTExpectFailure("string should not start with T") {
-            _ = expect("The Great White North").toNot.contain("Hosehead").and.startWith("T")
+        expectFailure("string should not start with T") {
+            expect("The Great White North").toNot.contain("Hosehead").and.startWith("T")
         }
     }
 }

--- a/Tests/Specs/Matchers/EndWithSpec.swift
+++ b/Tests/Specs/Matchers/EndWithSpec.swift
@@ -5,44 +5,40 @@ final class EndWithSpec: XCTestCase {
     func testToEndWith() {
         expect([1, 2, 3]).to.endWith(3)
         
-        // Note: The '_ =' is only used to silence a warning from XCTExpectFailure
-        // throughout the specs
-        // This is not required for usage
-        
-        XCTExpectFailure("array should not end with four") {
-            _ = expect(["one", "two", "three"]).to.endWith("four")
+        expectFailure("array should not end with four") {
+            expect(["one", "two", "three"]).to.endWith("four")
         }
     }
     
     func testToNotEndWith() {
         expect([4, 5, 6]).toNot.endWith(1)
         
-        XCTExpectFailure("array should end with c") {
-            _ = expect(["a", "b", "c"]).toNot.endWith("c")
+        expectFailure("array should end with c") {
+            expect(["a", "b", "c"]).toNot.endWith("c")
         }
     }
     
     func testToEndWithCompoundMatcher() {
         expect([1, 2, 3]).to.endWith(3).and.startWith(1)
         
-        XCTExpectFailure("array should not end with four") {
-            _ = expect(["one", "two", "three"]).to.endWith("four").and.startWith("one")
+        expectFailure("array should not end with four") {
+            expect(["one", "two", "three"]).to.endWith("four").and.startWith("one")
         }
         
-        XCTExpectFailure("array should not start with four") {
-            _ = expect(["one", "two", "three"]).to.endWith("three").and.startWith("four")
+        expectFailure("array should not start with four") {
+            expect(["one", "two", "three"]).to.endWith("three").and.startWith("four")
         }
     }
     
     func testToNotEndWithCompoundMatcher() {
         expect([1, 2, 3]).toNot.endWith(7).and.startWith(4)
         
-        XCTExpectFailure("array should not end with three") {
-            _ = expect(["one", "two", "three"]).toNot.endWith("three").and.startWith("one")
+        expectFailure("array should not end with three") {
+            expect(["one", "two", "three"]).toNot.endWith("three").and.startWith("one")
         }
         
-        XCTExpectFailure("array should not start with one") {
-            _ = expect(["one", "two", "three"]).toNot.endWith("se7en").and.startWith("one")
+        expectFailure("array should not start with one") {
+            expect(["one", "two", "three"]).toNot.endWith("se7en").and.startWith("one")
         }
     }
 }

--- a/Tests/Specs/Matchers/EqualSpec.swift
+++ b/Tests/Specs/Matchers/EqualSpec.swift
@@ -16,7 +16,7 @@ final class EqualSpec: XCTestCase {
     func testToEqual() {
         expect(99).to.equal(99)
         
-        XCTExpectFailure("99 should not equal 100") {
+        expectFailure("99 should not equal 100") {
             expect(99).to.equal(100)
         }
     }
@@ -24,7 +24,7 @@ final class EqualSpec: XCTestCase {
     func testToNotEqual() {
         expect(99).toNot.equal(100)
         
-        XCTExpectFailure("99 should equal 99") {
+        expectFailure("99 should equal 99") {
             expect(99).toNot.equal(99)
         }
     }
@@ -32,7 +32,7 @@ final class EqualSpec: XCTestCase {
     func testToEqualWithAccuracy() {
         expect(9.9).to.equal(9.9, within: 0.1)
         
-        XCTExpectFailure("9.9 should not equal 10.9 within 0.1") {
+        expectFailure("9.9 should not equal 10.9 within 0.1") {
             expect(9.9).to.equal(10.9, within: 0.1)
         }
     }
@@ -40,7 +40,7 @@ final class EqualSpec: XCTestCase {
     func testToNotEqualWithAccuracy() {
         expect(9.9).to.equal(9.9, within: 0.1)
         
-        XCTExpectFailure("9.9 should equal 9.9 within 0.1") {
+        expectFailure("9.9 should equal 9.9 within 0.1") {
             expect(9.9).toNot.equal(9.9, within: 0.1)
         }
     }

--- a/Tests/Specs/Matchers/HaveMaxValueOfSpec.swift
+++ b/Tests/Specs/Matchers/HaveMaxValueOfSpec.swift
@@ -5,44 +5,40 @@ final class HaveMaxValueOfSpec: XCTestCase {
     func testToHaveMaxValueOf() {
         expect([1, 7, 1]).to.haveMaxValueOf(7)
         
-        // Note: The '_ =' is only used to silence a warning from XCTExpectFailure
-        // throughout the specs
-        // This is not required for usage
-        
-        XCTExpectFailure("array should have max value of 1") {
-            _ = expect([1, 1, 1]).to.haveMaxValueOf(8)
+        expectFailure("array should have max value of 1") {
+            expect([1, 1, 1]).to.haveMaxValueOf(8)
         }
     }
     
     func testToNotHaveMaxValueOf() {
         expect([1, 7, 10]).toNot.haveMaxValueOf(9)
         
-        XCTExpectFailure("array should not have max value of 1") {
-            _ = expect([1, 1, 1]).toNot.haveMaxValueOf(1)
+        expectFailure("array should not have max value of 1") {
+            expect([1, 1, 1]).toNot.haveMaxValueOf(1)
         }
     }
     
     func testToHaveMaxValueWithCompoundMatcher() {
         expect([9, 9, 0]).to.haveMaxValueOf(9).and.startWith(9)
         
-        XCTExpectFailure("array should have a max value of 1") {
-            _ = expect([1, 1, 1]).to.haveMaxValueOf(2).and.startWith(1)
+        expectFailure("array should have a max value of 1") {
+            expect([1, 1, 1]).to.haveMaxValueOf(2).and.startWith(1)
         }
         
-        XCTExpectFailure("array should not start with 9") {
-            _ = expect([1, 1, 1]).to.haveMaxValueOf(1).and.startWith(9)
+        expectFailure("array should not start with 9") {
+            expect([1, 1, 1]).to.haveMaxValueOf(1).and.startWith(9)
         }
     }
     
     func testToNotHaveMaxValueWithCompoundMatcher() {
         expect([BJJBelt.white, BJJBelt.red]).toNot.haveMaxValueOf(.black).and.startWith(.red)
         
-        XCTExpectFailure("array should not have a max value of red") {
-            _ = expect([BJJBelt.white, BJJBelt.red]).toNot.haveMaxValueOf(.red).and.startWith(.blue)
+        expectFailure("array should not have a max value of red") {
+            expect([BJJBelt.white, BJJBelt.red]).toNot.haveMaxValueOf(.red).and.startWith(.blue)
         }
         
-        XCTExpectFailure("array should not end with red") {
-            _ = expect([BJJBelt.white, BJJBelt.red]).toNot.haveMaxValueOf(.white).and.endWith(.red)
+        expectFailure("array should not end with red") {
+            expect([BJJBelt.white, BJJBelt.red]).toNot.haveMaxValueOf(.white).and.endWith(.red)
         }
     }
 }

--- a/Tests/Specs/Matchers/HaveMinValueOfSpec.swift
+++ b/Tests/Specs/Matchers/HaveMinValueOfSpec.swift
@@ -5,44 +5,40 @@ final class HaveMinValueOfSpec: XCTestCase {
     func testToHaveMinValueOf() {
         expect([1, 7, 1]).to.haveMinValueOf(1)
         
-        // Note: The '_ =' is only used to silence a warning from XCTExpectFailure
-        // throughout the specs
-        // This is not required for usage
-        
-        XCTExpectFailure("array should have min value of 1") {
-            _ = expect([1, 1, 1]).to.haveMinValueOf(8)
+        expectFailure("array should have min value of 1") {
+            expect([1, 1, 1]).to.haveMinValueOf(8)
         }
     }
     
     func testToNotHaveMinValueOf() {
         expect([1, 7, 10]).toNot.haveMinValueOf(7)
         
-        XCTExpectFailure("array should not have min value of 1") {
-            _ = expect([1, 1, 1]).toNot.haveMinValueOf(1)
+        expectFailure("array should not have min value of 1") {
+            expect([1, 1, 1]).toNot.haveMinValueOf(1)
         }
     }
     
     func testToHaveMinValueWithCompoundMatcher() {
         expect([9, 9, 0]).to.haveMinValueOf(0).and.startWith(9)
         
-        XCTExpectFailure("array should have a min value of 1") {
-            _ = expect([1, 1, 1]).to.haveMinValueOf(2).and.startWith(1)
+        expectFailure("array should have a min value of 1") {
+            expect([1, 1, 1]).to.haveMinValueOf(2).and.startWith(1)
         }
         
-        XCTExpectFailure("array should not start with 9") {
-            _ = expect([1, 1, 1]).to.haveMinValueOf(1).and.startWith(9)
+        expectFailure("array should not start with 9") {
+            expect([1, 1, 1]).to.haveMinValueOf(1).and.startWith(9)
         }
     }
     
     func testToNotHaveMinValueWithCompoundMatcher() {
         expect([BJJBelt.white, BJJBelt.red]).toNot.haveMinValueOf(.black).and.startWith(.red)
         
-        XCTExpectFailure("array should have min value of white") {
-            _ = expect([BJJBelt.white, BJJBelt.red]).toNot.haveMinValueOf(.white).and.endWith(.white)
+        expectFailure("array should have min value of white") {
+            expect([BJJBelt.white, BJJBelt.red]).toNot.haveMinValueOf(.white).and.endWith(.white)
         }
         
-        XCTExpectFailure("array should not end with red") {
-            _ = expect([BJJBelt.white, BJJBelt.red]).toNot.haveMinValueOf(.white).and.endWith(.red)
+        expectFailure("array should not end with red") {
+            expect([BJJBelt.white, BJJBelt.red]).toNot.haveMinValueOf(.white).and.endWith(.red)
         }
     }
 }

--- a/Tests/Specs/Matchers/HaveSizeOfSpec.swift
+++ b/Tests/Specs/Matchers/HaveSizeOfSpec.swift
@@ -5,44 +5,40 @@ final class HaveSizeOfSpec: XCTestCase {
     func testToHaveSizeOf() {
         expect([1, 2, 3]).to.haveSizeOf(3)
         
-        // Note: The '_ =' is only used to silence a warning from XCTExpectFailure
-        // throughout the specs
-        // This is not required for usage
-        
-        XCTExpectFailure("array should not have a size of 4") {
-            _ = expect(["one", "two", "three"]).to.haveSizeOf(4)
+        expectFailure("array should not have a size of 4") {
+            expect(["one", "two", "three"]).to.haveSizeOf(4)
         }
     }
     
     func testToNotHaveSizeOf() {
         expect([1, 2, 3]).toNot.haveSizeOf(99)
         
-        XCTExpectFailure("array should have a size of 3") {
-            _ = expect(["one", "two", "three"]).toNot.haveSizeOf(3)
+        expectFailure("array should have a size of 3") {
+            expect(["one", "two", "three"]).toNot.haveSizeOf(3)
         }
     }
     
     func testToHaveSizeOfWithCompoundMatcher() {
         expect([1, 2, 3]).to.haveSizeOf(3).and.startWith(1)
         
-        XCTExpectFailure("array should have a size of 3") {
-            _ = expect([1, 2, 3]).to.haveSizeOf(4).and.startWith(1)
+        expectFailure("array should have a size of 3") {
+            expect([1, 2, 3]).to.haveSizeOf(4).and.startWith(1)
         }
         
-        XCTExpectFailure("array should not start with 2") {
-            _ = expect([1, 2, 3]).to.haveSizeOf(3).and.startWith(2)
+        expectFailure("array should not start with 2") {
+            expect([1, 2, 3]).to.haveSizeOf(3).and.startWith(2)
         }
     }
     
     func testToNotHaveSizeOfWithCompoundMatcher() {
         expect([1, 2, 3]).toNot.haveSizeOf(1).and.startWith(2)
         
-        XCTExpectFailure("array should have a size of 3") {
-            _ = expect([1, 2, 3]).toNot.haveSizeOf(3).and.startWith(2)
+        expectFailure("array should have a size of 3") {
+            expect([1, 2, 3]).toNot.haveSizeOf(3).and.startWith(2)
         }
         
-        XCTExpectFailure("array should not start with 1") {
-            _ = expect([1, 2, 3]).toNot.haveSizeOf(99).and.startWith(1)
+        expectFailure("array should not start with 1") {
+            expect([1, 2, 3]).toNot.haveSizeOf(99).and.startWith(1)
         }
     }
 }

--- a/Tests/Specs/Matchers/StartWithSpec.swift
+++ b/Tests/Specs/Matchers/StartWithSpec.swift
@@ -5,44 +5,40 @@ final class StartWithSpec: XCTestCase {
     func testToStartWith() {
         expect([1, 2, 3]).to.startWith(1)
         
-        // Note: The '_ =' is only used to silence a warning from XCTExpectFailure
-        // throughout the specs
-        // This is not required for usage
-        
-        XCTExpectFailure("array should not start with four") {
-            _ = expect(["one", "two", "three"]).to.startWith("four")
+        expectFailure("array should not start with four") {
+            expect(["one", "two", "three"]).to.startWith("four")
         }
     }
     
     func testToNotStartWith() {
         expect([4, 5, 6]).toNot.startWith(1)
         
-        XCTExpectFailure("array should start with four") {
-            _ = expect(["four", "five", "six"]).toNot.startWith("four")
+        expectFailure("array should start with four") {
+            expect(["four", "five", "six"]).toNot.startWith("four")
         }
     }
     
     func testToStartWithCompoundMatcher() {
         expect([1, 2, 3]).to.startWith(1).and.endWith(3)
         
-        XCTExpectFailure("array should not start with four") {
-            _ = expect(["one", "two", "three"]).to.startWith("four").and.endWith("three")
+        expectFailure("array should not start with four") {
+            expect(["one", "two", "three"]).to.startWith("four").and.endWith("three")
         }
         
-        XCTExpectFailure("array should not end with four") {
-            _ = expect(["one", "two", "three"]).to.startWith("one").and.endWith("four")
+        expectFailure("array should not end with four") {
+            expect(["one", "two", "three"]).to.startWith("one").and.endWith("four")
         }
     }
     
     func testToNotStartWithCompoundMatcher() {
         expect([1, 2, 3]).toNot.startWith(7).and.endWith(4)
         
-        XCTExpectFailure("array should not start with one") {
-            _ = expect(["one", "two", "three"]).toNot.startWith("one").and.endWith("four")
+        expectFailure("array should not start with one") {
+            expect(["one", "two", "three"]).toNot.startWith("one").and.endWith("four")
         }
         
-        XCTExpectFailure("array should not end with three") {
-            _ = expect(["one", "two", "three"]).toNot.startWith("se7en").and.endWith("three")
+        expectFailure("array should not end with three") {
+            expect(["one", "two", "three"]).toNot.startWith("se7en").and.endWith("three")
         }
     }
 }

--- a/Tests/Specs/Matchers/ThrowErrorSpec.swift
+++ b/Tests/Specs/Matchers/ThrowErrorSpec.swift
@@ -17,11 +17,11 @@ final class ThrowErrorSpec: XCTestCase {
         // Note: This expect has a function type of () throws-> String
         // instead of () throws -> Void
         
-        XCTExpectFailure("expect should have proper closure structure") {
+        expectFailure("expect should have proper closure structure") {
             expect({ try self.dog.bark(shouldThroughExceptionalBark: true) }).to.throwError()
         }
         
-        XCTExpectFailure("dog should not throw error") {
+        expectFailure("dog should not throw error") {
             expect({ try _ = self.dog.bark(shouldThroughExceptionalBark: false) }).to.throwError()
         }
     }
@@ -29,13 +29,13 @@ final class ThrowErrorSpec: XCTestCase {
     func testToNotThrowError() {
         expect({ try _ = self.dog.bark(shouldThroughExceptionalBark: false) }).toNot.throwError()
         
-        XCTExpectFailure("dog should not throw error") {
+        expectFailure("dog should not throw error") {
             expect({ try _ = self.dog.bark(shouldThroughExceptionalBark: true) }).toNot.throwError()
         }
     }
     
     func testToThrowErrorWithErrorHandler() {
-        expect { try _ = self.dog.bark(shouldThroughExceptionalBark: true) }
+        expect({ try _ = self.dog.bark(shouldThroughExceptionalBark: true) })
             .to.throwError { error in
                 expect(error as? BarkException).to.equal(.earShrikingBark)
         }
@@ -46,7 +46,7 @@ final class ThrowErrorSpec: XCTestCase {
     
     func testToNotThrowErrorWithErrorHandler() {
         XCTExpectFailure("dog should not throw error") {
-            expect { try _ = self.dog.bark(shouldThroughExceptionalBark: false) }
+            expect({ try _ = self.dog.bark(shouldThroughExceptionalBark: false) })
                 .toNot.throwError { error in
                     expect(error as? BarkException).to.equal(.earShrikingBark)
             }
@@ -56,11 +56,11 @@ final class ThrowErrorSpec: XCTestCase {
     func testToThrowErrorWithSpecificError() {
         expect({ try _ = self.dog.bark(shouldThroughExceptionalBark: true) }).to.throwError(specificError: BarkException.earShrikingBark)
         
-        XCTExpectFailure("dog should not throw error") {
+        expectFailure("dog should not throw error") {
             expect({ try _ = self.dog.bark(shouldThroughExceptionalBark: false) }).to.throwError(specificError: BarkException.deafeningBark)
         }
         
-        XCTExpectFailure("dog should not throw deafeningBark error") {
+        expectFailure("dog should not throw deafeningBark error") {
             expect({ try _ = self.dog.bark(shouldThroughExceptionalBark: true) }).to.throwError(specificError: BarkException.deafeningBark)
         }
     }
@@ -70,7 +70,7 @@ final class ThrowErrorSpec: XCTestCase {
         
         expect({ try _ = self.dog.bark(shouldThroughExceptionalBark: true) }).toNot.throwError(specificError: MeowException.purrr)
         
-        XCTExpectFailure("dog should throw BarkException.earShrinkingBark") {
+        expectFailure("dog should throw BarkException.earShrinkingBark") {
             expect({ try _ = self.dog.bark(shouldThroughExceptionalBark: true) }).toNot.throwError(specificError: BarkException.earShrikingBark)
         }
     }


### PR DESCRIPTION
`expectFailure` wraps `XCTExpectFailure` but removes warning with unused results that are given with compound matching.